### PR TITLE
task: Remove picture params from update endpoint

### DIFF
--- a/communicate-with-ruuvi-cloud/cloud/user-api/README.md
+++ b/communicate-with-ruuvi-cloud/cloud/user-api/README.md
@@ -524,8 +524,7 @@ Updates sensor metadata.
 #### Request Body
 
 | Name              | Type    | Description                                                                                        |
-| ----------------- | ------- | -------------------------------------------------------------------------------------------------- |
-| picture           | string  | Filename of a picture (or URL if uploaded)                                                         |
+| ----------------- | ------- | -------------------------------------------------------------------------------------------------- |                             
 | offsetHumidity    | number  | Offset humidity to calibrate sensor                                                                |
 | offsetPressure    | number  | Offset pressure to calibrate sensor                                                                |
 | offsetTemperature | number  | Offset temperature to calibrate sensor                                                             |


### PR DESCRIPTION
This is to avoid allowing arbitrary URL as picture image which can break things and produce unexpected results.